### PR TITLE
BLD: All files in psbeam/images are included

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include psbeam/_version.py
+recursive-include psbeam/images *

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(name        = 'psbeam',
       license     = 'BSD',
       author      = 'SLAC National Accelerator Laboratory',
       packages    = find_packages(),
+      include_package_data = True      
       )


### PR DESCRIPTION
This fixes the issue where the images would not be part of the repo when installed. 